### PR TITLE
James/graphql edge cases

### DIFF
--- a/schema.ts
+++ b/schema.ts
@@ -97,6 +97,7 @@ const RootQuery = new GraphQLObjectType({
       type: PersonType,
       args: {
         id: { type: GraphQLInt },
+        test: { type: GraphQLString },
       },
       resolve: async (
         _parent: any,

--- a/schemaExecutable.ts
+++ b/schemaExecutable.ts
@@ -39,8 +39,8 @@ const typeDefs = gql`
     onePerson(id: ID): PersonType
   }
 `;
-console.log('typedefs-->', typeDefs);
+// console.log('typedefs-->', typeDefs);
 
 const schema = makeExecutableSchema({ typeDefs, resolvers });
-console.log('schema: ', schema);
+// console.log('schema: ', schema);
 export default schema;

--- a/schemaSpacex.ts
+++ b/schemaSpacex.ts
@@ -1,0 +1,75 @@
+import {
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLBoolean,
+  GraphQLFloat,
+} from 'https://deno.land/x/graphql_deno@v15.0.0/mod.ts';
+
+const RocketType = new GraphQLObjectType({
+  name: 'Rocket',
+  fields: () => ({
+    id: { type: GraphQLInt },
+    active: { type: GraphQLBoolean },
+    stages: { type: GraphQLInt },
+    first_flight: { type: GraphQLString },
+    country: { type: GraphQLString },
+    height: { type: HeightType },
+    diameter: { type: DiameterType },
+    wikipedia: { type: GraphQLString },
+    description: { type: GraphQLString },
+    rocket_id: { type: GraphQLString },
+    rocket_name: { type: GraphQLString },
+    rocket_type: { type: GraphQLString },
+  }),
+});
+
+const HeightType = new GraphQLObjectType({
+  name: 'Height',
+  fields: () => ({
+    meters: { type: GraphQLFloat },
+    feet: { type: GraphQLFloat },
+  }),
+});
+
+const DiameterType = new GraphQLObjectType({
+  name: 'Diameter',
+  fields: () => ({
+    meters: { type: GraphQLFloat },
+    feet: { type: GraphQLFloat },
+  }),
+});
+
+const RootQuery = new GraphQLObjectType({
+  name: 'RootQueryType',
+  fields: {
+    rocket: {
+      type: GraphQLList(RocketType),
+      resolve: async (_parent: any, _args: any, context: any, info: any) => {
+        return await context.denostore.cache({ info }, async () => {
+          return await fetch('https://api.spacexdata.com/v3/rockets').then(
+            (res) => res.json()
+          );
+        });
+      },
+    },
+    oneRocket: {
+      type: RocketType,
+      args: {
+        id: { type: GraphQLString },
+      },
+      resolve: async (_parent: any, args: any, context: any, info: any) => {
+        return await context.denostore.cache({ info }, async () => {
+          return await fetch(
+            `https://api.spacexdata.com/v3/rockets/${args.id}`
+          ).then((res) => res.json());
+        });
+      },
+    },
+  },
+});
+
+const schema = new GraphQLSchema({ query: RootQuery });
+export default schema;

--- a/server.ts
+++ b/server.ts
@@ -1,8 +1,8 @@
 import { Application } from 'https://deno.land/x/oak@v10.2.0/mod.ts';
 import { connect } from 'https://deno.land/x/redis@v0.25.2/mod.ts';
 import Denostore from './src/denostore.ts';
-// import schema from './schema.ts';
-import schema from './schemaExecutable.ts';
+import schema from './schema.ts';
+// import schema from './schemaExecutable.ts';
 
 const PORT = 3000;
 

--- a/server.ts
+++ b/server.ts
@@ -1,8 +1,9 @@
 import { Application } from 'https://deno.land/x/oak@v10.2.0/mod.ts';
 import { connect } from 'https://deno.land/x/redis@v0.25.2/mod.ts';
 import Denostore from './src/denostore.ts';
-import schema from './schema.ts';
+// import schema from './schema.ts';
 // import schema from './schemaExecutable.ts';
+import schema from './schemaSpacex.ts';
 
 const PORT = 3000;
 

--- a/src/denostore.ts
+++ b/src/denostore.ts
@@ -1,7 +1,7 @@
 import { Router } from 'https://deno.land/x/oak@v10.2.0/mod.ts';
 import { renderPlaygroundPage } from 'https://deno.land/x/oak_graphql@0.6.3/graphql-playground-html/render-playground-html.ts';
 import { graphql } from 'https://deno.land/x/graphql_deno@v15.0.0/mod.ts';
-import { queryParser, queryExtract } from './utils.ts';
+import { queryExtract } from './utils.ts';
 
 import type {
   Redis,
@@ -38,16 +38,15 @@ export default class Denostore {
     // deno-lint-ignore ban-types
     callback: { (): Promise<{}> | {} }
   ) {
-    // console.log('info-->', info.fieldNodes);
+    console.log('info-->', info.fieldNodes.length);
+    // const queryExtractName = queryExtract(info.fieldNodes[0]);
+    // console.log('queryExtractName-->', queryExtractName);
+    // const value = await this.#redisClient.get(queryExtractName);
+
     const queryExtractName = queryExtract(info.fieldNodes[0]);
     console.log(queryExtractName);
     const value = await this.#redisClient.get(queryExtractName);
 
-    // //check if query is a fragment or not.
-    // if (Object.keys(info.fragments).length) {
-    //   // temporary solution is to direct it straight to callback
-    //   return await callback();
-    // }
     // // error check here for missing query on info obj
     // const queryString = info.operation.selectionSet.loc
     //   ? info.operation.selectionSet.loc.source.body
@@ -78,7 +77,9 @@ export default class Denostore {
     }
     console.log('cache miss');
     // await this.#redisClient.set(queryName, JSON.stringify(results)); //this would be setex for expiration
-    await this.#redisClient.set(queryExtractName, JSON.stringify(results)); //this would be setex for expiration
+    // await this.#redisClient.set(queryExtractName, JSON.stringify(results));
+    await this.#redisClient.set(queryExtractName, JSON.stringify(results));
+
     return results;
   }
 

--- a/src/denostore.ts
+++ b/src/denostore.ts
@@ -38,6 +38,15 @@ export default class Denostore {
     // deno-lint-ignore ban-types
     callback: { (): Promise<{}> | {} }
   ) {
+    // console.log(Boolean(Object.keys(info.fragments).length));
+    // console.log(Object.keys(info.fragments).length);
+    console.log('info-->', info.fieldNodes);
+
+    //check if query is a fragment or not.
+    if (Object.keys(info.fragments).length) {
+      // temporary solution is to direct it straight to callback
+      return await callback();
+    }
     // error check here for missing query on info obj
     const queryString = info.operation.selectionSet.loc
       ? info.operation.selectionSet.loc.source.body

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ import type { Redis } from 'https://deno.land/x/redis@v0.25.3/mod.ts';
 import type {
   GraphQLSchema,
   GraphQLResolveInfo,
+  FieldNode,
+  ArgumentNode,
 } from 'https://deno.land/x/graphql_deno@v15.0.0/mod.ts';
 import type {
   Middleware,
@@ -16,4 +18,16 @@ export interface DenostoreArgs {
   defaultCacheExpire?: number | boolean;
 }
 
-export type { Redis, GraphQLSchema, GraphQLResolveInfo, Middleware, Context };
+export interface QueryObjType {
+  readonly name: string;
+  readonly arguments?: ReadonlyArray<ArgumentNode>;
+}
+
+export type {
+  Redis,
+  GraphQLSchema,
+  GraphQLResolveInfo,
+  Middleware,
+  Context,
+  FieldNode,
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,4 +26,18 @@ const queryParser = (queryString: string): string => {
   return queryName;
 };
 
-export { queryParser };
+const queryExtract = (node: any): string => {
+  let queryName = '';
+  queryName += node.name.value;
+  if (node.arguments.length) {
+    queryName += '(';
+    node.arguments.forEach((arg: any, i: number) => {
+      if (i > 0) queryName += ',';
+      queryName += arg.name.value + ':' + arg.value.value;
+    });
+    queryName += ')';
+  }
+  return queryName;
+};
+
+export { queryParser, queryExtract };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,43 +1,41 @@
-const queryParser = (queryString: string): string => {
-  if (queryString === '') {
-    console.error(
-      '%cError finding query in the resolver.',
-      'font-weight: bold; color: white; background-color: red;'
-    );
-    throw new Error('Query error. See server console.');
-  }
-  if (queryString[0] === 'm') {
-    console.error(
-      '%cDenostore cache function does not allow caching of mutations.',
-      'font-weight: bold; color: white; background-color: red;'
-    );
-    throw new Error('Query error. See server console.');
-  }
-  let queryName = '';
-  let curlyCount = 0;
+import { QueryObjType, FieldNode } from './types.ts';
 
-  for (let i = 0; i < queryString.length && curlyCount < 2; i++) {
-    if (queryString[i] === '{') curlyCount++;
-    if (curlyCount === 1 && queryString[i] !== '{') {
-      queryName += queryString[i];
-    }
-  }
-  queryName = queryName.trim();
-  return queryName;
+// const queryParser = (queryString: string): string => {
+//   if (queryString === '') {
+//     console.error(
+//       '%cError finding query in the resolver.',
+//       'font-weight: bold; color: white; background-color: red;'
+//     );
+//     throw new Error('Query error. See server console.');
+//   }
+//   if (queryString[0] === 'm') {
+//     console.error(
+//       '%cDenostore cache function does not allow caching of mutations.',
+//       'font-weight: bold; color: white; background-color: red;'
+//     );
+//     throw new Error('Query error. See server console.');
+//   }
+//   let queryName = '';
+//   let curlyCount = 0;
+
+//   for (let i = 0; i < queryString.length && curlyCount < 2; i++) {
+//     if (queryString[i] === '{') curlyCount++;
+//     if (curlyCount === 1 && queryString[i] !== '{') {
+//       queryName += queryString[i];
+//     }
+//   }
+//   queryName = queryName.trim();
+//   return queryName;
+// };
+
+const queryExtract = (node: FieldNode): string => {
+  const queryObj: QueryObjType = {
+    name: node.name.value,
+    arguments: node.arguments,
+  };
+
+  //find node name value as one key, args on another key
+  return JSON.stringify(queryObj);
 };
 
-const queryExtract = (node: any): string => {
-  let queryName = '';
-  queryName += node.name.value;
-  if (node.arguments.length) {
-    queryName += '(';
-    node.arguments.forEach((arg: any, i: number) => {
-      if (i > 0) queryName += ',';
-      queryName += arg.name.value + ':' + arg.value.value;
-    });
-    queryName += ')';
-  }
-  return queryName;
-};
-
-export { queryParser, queryExtract };
+export { queryExtract };


### PR DESCRIPTION
new approach to getting the string for the redis key.

Instead of accessing and parsing through the graphql query string, we are going through the GraphQL info AST and get query name and arguments and saving them in an object. Then we use JSON stringify and return that string to be used as the key of the redis property. 

Also, we added a basic SpaceX schema to test nested queries to see if it would work. At the moment we have tested with fragments and aliases. 