### PR TITLE
Added option to specify cache expire time

### DIFF
--- a/schemaSpacex.ts
+++ b/schemaSpacex.ts
@@ -61,7 +61,7 @@ const RootQuery = new GraphQLObjectType({
         id: { type: GraphQLString },
       },
       resolve: async (_parent: any, args: any, context: any, info: any) => {
-        return await context.denostore.cache({ info }, async () => {
+        return await context.denostore.cache({ info: info, ex: 5 }, async () => { // expire after 5 seconds
           return await fetch(
             `https://api.spacexdata.com/v3/rockets/${args.id}`
           ).then((res) => res.json());

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Redis } from 'https://deno.land/x/redis@v0.25.3/mod.ts';
+import type { Redis, SetOpts } from 'https://deno.land/x/redis@v0.25.3/mod.ts';
 import type {
   GraphQLSchema,
   GraphQLResolveInfo,
@@ -33,4 +33,5 @@ export type {
   Middleware,
   Context,
   FieldNode,
+  SetOpts,
 };


### PR DESCRIPTION
User can now add the 'ex' property to the options object with a value of seconds until expire. 

denostore.cache({ info: info, ex: 5 ), callback)

This will pass the expire time in seconds as an option to the redis set method and the cache will expire as instructed.