### PR TITLE
Can now set default expire when instantiating denostore

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -21,6 +21,7 @@ const denostore = new Denostore({
   usePlayground: true,
   schema,
   redisClient,
+  defaultEx: 10,
 });
 
 app.use(denostore.routes(), denostore.allowedMethods());

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface DenostoreArgs {
   redisClient: Redis;
   route?: string;
   usePlayground?: boolean;
-  defaultCacheExpire?: number | boolean;
+  defaultEx?: number | null;
 }
 
 type Maybe<T> = null | undefined | T;


### PR DESCRIPTION
Can now set a default expire time in seconds when setting up denostore. This default expire time will be used if no expire argument is specified when using the cache function in your GraphQL schema. If no expire argument or default expire is specified, the results will be cached with no expiration.

const denostore = new Denostore({
  route: '/graphql',
  usePlayground: true,
  schema,
  redisClient,
  **defaultEx: 10,**
});