### PR TITLE
can now specify no expire

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface DenostoreArgs {
   redisClient: Redis;
   route?: string;
   usePlayground?: boolean;
-  defaultEx?: number | null;
+  defaultEx?: number | undefined;
 }
 
 type Maybe<T> = null | undefined | T;


### PR DESCRIPTION
User can now specify ex of -1 for queries they want no expiration time for.
`
context.denostore.cache({ info: info, ex: -1 }, callback)`