### PR TITLE
James/typedefs resolvers schema

### DIFF
--- a/schemaExecutable.ts
+++ b/schemaExecutable.ts
@@ -3,7 +3,7 @@ import { makeExecutableSchema } from 'https://deno.land/x/graphql_tools@0.0.2/mo
 import { gql } from 'https://deno.land/x/graphql_tag@0.0.1/mod.ts';
 import Denostore from './src/denostore.ts';
 
-const resolvers = {
+export const resolvers = {
   Query: {
     onePerson: async (
       _parent: any,
@@ -36,7 +36,7 @@ const resolvers = {
     },
   },
 };
-const typeDefs = gql`
+export const typeDefs = gql`
   type PersonType {
     name: String
     height: String
@@ -56,6 +56,5 @@ const typeDefs = gql`
 `;
 // console.log('typedefs-->', typeDefs);
 
-const schema = makeExecutableSchema({ typeDefs, resolvers });
+export const schema = makeExecutableSchema({ typeDefs, resolvers });
 // console.log('schema: ', schema);
-export default schema;

--- a/server.ts
+++ b/server.ts
@@ -2,8 +2,8 @@ import { Application } from 'https://deno.land/x/oak@v10.2.0/mod.ts';
 import { connect } from 'https://deno.land/x/redis@v0.25.2/mod.ts';
 import Denostore from './src/denostore.ts';
 // import schema from './schema.ts';
-import { typeDefs, resolvers } from './schemaExecutable.ts';
-// import { schema } from './schemaExecutable.ts';
+// import { typeDefs, resolvers } from './schemaExecutable.ts';
+import { schema } from './schemaExecutable.ts';
 // import schema from './schemaSpacex.ts';
 
 const PORT = 3000;
@@ -20,8 +20,9 @@ const redisClient = await connect({
 const denostore = new Denostore({
   route: '/graphql',
   usePlayground: true,
-  // schema,
-  schema: { typeDefs, resolvers },
+  schema,
+  // schema: { typeDefs, resolvers },
+  // schema: { typeDefs: resolvers, resolvers: typeDefs },
   redisClient,
   defaultEx: 10,
 });

--- a/server.ts
+++ b/server.ts
@@ -22,6 +22,7 @@ const denostore = new Denostore({
   usePlayground: true,
   schema,
   // schema: { typeDefs, resolvers },
+  // schema: { typeDefs: schema },
   // schema: { typeDefs: resolvers, resolvers: typeDefs },
   redisClient,
   defaultEx: 10,

--- a/server.ts
+++ b/server.ts
@@ -2,7 +2,8 @@ import { Application } from 'https://deno.land/x/oak@v10.2.0/mod.ts';
 import { connect } from 'https://deno.land/x/redis@v0.25.2/mod.ts';
 import Denostore from './src/denostore.ts';
 // import schema from './schema.ts';
-import schema from './schemaExecutable.ts';
+import { typeDefs, resolvers } from './schemaExecutable.ts';
+// import { schema } from './schemaExecutable.ts';
 // import schema from './schemaSpacex.ts';
 
 const PORT = 3000;
@@ -19,7 +20,8 @@ const redisClient = await connect({
 const denostore = new Denostore({
   route: '/graphql',
   usePlayground: true,
-  schema,
+  // schema,
+  schema: { typeDefs, resolvers },
   redisClient,
   defaultEx: 10,
 });

--- a/src/denostore.ts
+++ b/src/denostore.ts
@@ -40,7 +40,7 @@ export default class Denostore {
     this.#defaultEx = defaultEx;
   }
 
-  setSchemaProperty(schema: GraphQLSchema | ExecutableSchemaArgs) {
+  setSchemaProperty(schema: GraphQLSchema | ExecutableSchemaArgs): void {
     // takes in schema as an argument
     // checks if typedefs or resolver property is in schema
     if ('typeDefs' in schema || 'resolvers' in schema) {

--- a/src/denostore.ts
+++ b/src/denostore.ts
@@ -41,15 +41,16 @@ export default class Denostore {
   }
 
   setSchemaProperty(schema: GraphQLSchema | ExecutableSchemaArgs) {
-    // console.log('typeDefs-->', 'typeDefs' in schema);
-    // console.log('resolver-->', 'resolvers' in schema);
-
+    // takes in schema as an argument
+    // checks if typedefs or resolver property is in schema
     if ('typeDefs' in schema || 'resolvers' in schema) {
+      // set class property #schema with the schema that comes out of makeExecutableSchema function
       this.#schema = makeExecutableSchema({
         typeDefs: schema.typeDefs,
         resolvers: schema.resolvers,
       });
     } else {
+      // set class property #schema with the pass passed in
       this.#schema = schema;
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,13 +9,26 @@ import type {
   Middleware,
   Context,
 } from 'https://deno.land/x/oak@v10.2.0/mod.ts';
+import type {
+  ITypeDefinitions,
+  IResolvers,
+  ITypedef,
+} from 'https://deno.land/x/graphql_tools@0.0.2/utils/interfaces.ts';
 
 export interface DenostoreArgs {
-  schema: GraphQLSchema;
+  schema: GraphQLSchema | ExecutableSchemaArgs;
   redisClient: Redis;
   route?: string;
   usePlayground?: boolean;
   defaultEx?: number | undefined;
+}
+
+type ITypedefDS = (() => Array<ITypedefDS>) | string;
+
+export interface ExecutableSchemaArgs<TContext = any> {
+  typeDefs: ITypeDefinitions;
+  // typeDefs: ITypedefDS | Array<ITypedefDS>;
+  resolvers?: IResolvers<any, TContext> | Array<IResolvers<any, TContext>>;
 }
 
 type Maybe<T> = null | undefined | T;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,16 +4,15 @@ import type {
   GraphQLResolveInfo,
   FieldNode,
   ArgumentNode,
+  DocumentNode,
+  DefinitionNode,
+  Source,
 } from 'https://deno.land/x/graphql_deno@v15.0.0/mod.ts';
 import type {
   Middleware,
   Context,
 } from 'https://deno.land/x/oak@v10.2.0/mod.ts';
-import type {
-  ITypeDefinitions,
-  IResolvers,
-  ITypedef,
-} from 'https://deno.land/x/graphql_tools@0.0.2/utils/interfaces.ts';
+import type { IResolvers } from 'https://deno.land/x/graphql_tools@0.0.2/utils/interfaces.ts';
 
 export interface DenostoreArgs {
   schema: GraphQLSchema | ExecutableSchemaArgs;
@@ -23,12 +22,18 @@ export interface DenostoreArgs {
   defaultEx?: number | undefined;
 }
 
-type ITypedefDS = (() => Array<ITypedefDS>) | string;
+type ITypedefDS =
+  | string
+  | Source
+  | DocumentNode
+  | GraphQLSchema
+  | DefinitionNode
+  | Array<ITypedefDS>
+  | (() => ITypedefDS);
 
 export interface ExecutableSchemaArgs<TContext = any> {
-  typeDefs: ITypeDefinitions;
-  // typeDefs: ITypedefDS | Array<ITypedefDS>;
-  resolvers?: IResolvers<any, TContext> | Array<IResolvers<any, TContext>>;
+  typeDefs: ITypedefDS; // type definitions used to make schema
+  resolvers?: IResolvers<any, TContext> | Array<IResolvers<any, TContext>>; // resolvers for the type definitions
 }
 
 type Maybe<T> = null | undefined | T;


### PR DESCRIPTION
Implemented the ability to either pass in the typedefs/resolver or schema.
Either you pass it like:

new Denostore({
...
schema:schema
})

or 

new Denostore({
...
schema:{typeDefs: typeDefs, resolvers: resolvers}
})

Both ways work. Also for typeDefs/resolver, if you pass in resolver by accident, then it will throw a type error.

In terms of logic of how it works, schema can either be a GraphQLSchema or an object with typeDefs and resolver.

As Denostore is initialized, there is a function immediately ran in the constructor to set the schema for this instance. 

Added types for typeDefs/resolver using apollo-graphql as reference (creator of makeExecutableSchema)