### PR TITLE
Merging our tool to the main branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dump.rdb

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "deno.enable": true,
+  "deno.lint": true,
+  "deno.unstable": true
+}

--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,3 @@
 import Denostore from './src/denostore.ts';
 
-export default Denostore;
+export { Denostore };

--- a/mod.ts
+++ b/mod.ts
@@ -1,0 +1,3 @@
+import Denostore from './src/denostore.ts';
+
+export default Denostore;

--- a/src/denostore.ts
+++ b/src/denostore.ts
@@ -1,0 +1,98 @@
+import { Router } from 'https://deno.land/x/oak@v10.2.0/mod.ts';
+import { renderPlaygroundPage } from 'https://deno.land/x/oak_graphql@0.6.3/graphql-playground-html/render-playground-html.ts';
+import { graphql } from 'https://deno.land/x/graphql_deno@v15.0.0/mod.ts';
+import { RouterArgs } from './types.ts';
+import { queryParser } from './utils.ts';
+
+export default class Denostore {
+  #schema: any;
+  #usePlayground?: boolean;
+  #redisClient: any;
+  #router: any;
+
+  constructor(args: RouterArgs) {
+    const { schema, usePlayground, redisClient } = args;
+    this.#usePlayground = usePlayground;
+    this.#redisClient = redisClient;
+    this.#schema = schema;
+    this.#router = new Router();
+  }
+
+  async cache({ info }: { info: any }, callback: any) {
+    // if info.operation... is null, error handle, console.log(E01, message)
+    // if callback is undefined...
+
+    //sees if redisClient is already defined and if not assigns it to the client's passed in Redis
+    const queryName = queryParser(info.operation.selectionSet.loc.source.body);
+
+    const value = await this.#redisClient.get(queryName);
+    // cache hit: respond with parsed data
+    let results;
+    if (value) {
+      console.log('returning cached result');
+      results = JSON.parse(value);
+      return results;
+    }
+
+    //cache miss: set cache and respond with results
+    console.log('cache miss');
+    results = await callback();
+    await this.#redisClient.set(queryName, JSON.stringify(results)); //this would be setex for expiration
+    return results;
+  }
+
+  async clear(): Promise<void> {
+    //sees if redisClient is already defined and if not assigns it to the client's passed in Redis
+    await this.#redisClient.flushall();
+    console.log('cleared cache');
+  }
+
+  routes(): any {
+    //check if usePlayground is passed in truthy and render playground
+    if (this.#usePlayground) {
+      //renders pseudo-graphiql using playground GUI
+      this.#router.get('/graphql', (ctx: any) => {
+        const { request, response } = ctx;
+        const playground = renderPlaygroundPage({
+          endpoint: request.url.origin + '/graphql',
+        });
+        response.status = 200;
+        response.body = playground;
+        return;
+      });
+    }
+
+    //handles posted query and responds
+    this.#router.post('/graphql', async (ctx: any) => {
+      const { response, request } = ctx;
+      const body = await request.body();
+      const { query } = await body.value;
+      //caching happens inside of resolvers (nested within schema, so graphql func invocation)
+      const results = await graphql({
+        schema: this.#schema,
+        source: query,
+        contextValue: { denostore: this },
+      });
+      response.status = 200;
+      if (results.errors) response.status = 500;
+      response.body = results;
+      return;
+    });
+
+    this.#router.delete('/delete', (ctx: any) => {
+      this.#redisClient.flushall();
+
+      console.log('Deleted Cache');
+
+      ctx.response.status = 202;
+      ctx.response.body = 'Cleared Cache';
+      return;
+    });
+
+    return this.#router.routes();
+  }
+
+  allowedMethods(): any {
+    return this.#router.allowedMethods();
+  }
+}

--- a/src/denostore.ts
+++ b/src/denostore.ts
@@ -10,7 +10,7 @@ import type {
   DenostoreArgs,
   Middleware,
   Context,
-  SetOpts
+  SetOpts,
 } from './types.ts';
 
 export default class Denostore {
@@ -38,10 +38,11 @@ export default class Denostore {
   }
 
   async cache(
-    { info, ex }: { info: GraphQLResolveInfo, ex?: number },
+    { info, ex }: { info: GraphQLResolveInfo; ex?: number },
     // deno-lint-ignore ban-types
     callback: { (): Promise<{}> | {} }
   ) {
+    // console.log(info);
     // extract query name from info object
     const queryExtractName = queryExtract(info);
     // console.log(queryExtractName);
@@ -66,22 +67,27 @@ export default class Denostore {
     }
 
     console.log('cache miss');
-    
+
     // declare opts variable
     let opts: SetOpts | undefined;
 
     // if positive expire argument specified, set expire in options
     if (ex) {
-      if (ex > 0) opts = { ex: ex }
+      if (ex > 0) opts = { ex: ex };
       // if expire arg not specified look for default expiration
     } else if (this.#defaultEx) {
-      opts = { ex: this.#defaultEx }
+      opts = { ex: this.#defaultEx };
     }
 
     // set cache with options if specified
-    opts ? await this.#redisClient.set(queryExtractName, JSON.stringify(results), opts) 
-      // if no options specified set cache with no expiration
-      : await this.#redisClient.set(queryExtractName, JSON.stringify(results));
+    opts
+      ? await this.#redisClient.set(
+          queryExtractName,
+          JSON.stringify(results),
+          opts
+        )
+      : // if no options specified set cache with no expiration
+        await this.#redisClient.set(queryExtractName, JSON.stringify(results));
 
     return results;
   }
@@ -122,6 +128,7 @@ export default class Denostore {
       try {
         const body = await request.body();
         const { query, variables } = await body.value;
+
         //caching happens inside of resolvers (nested within schema, so graphql func invocation)
         const results = await graphql({
           schema: this.#schema,

--- a/src/denostore.ts
+++ b/src/denostore.ts
@@ -1,63 +1,95 @@
 import { Router } from 'https://deno.land/x/oak@v10.2.0/mod.ts';
 import { renderPlaygroundPage } from 'https://deno.land/x/oak_graphql@0.6.3/graphql-playground-html/render-playground-html.ts';
 import { graphql } from 'https://deno.land/x/graphql_deno@v15.0.0/mod.ts';
-import { queryExtract } from './utils.ts';
+import { connect } from 'https://deno.land/x/redis@v0.25.2/mod.ts';
+import { makeExecutableSchema } from 'https://deno.land/x/graphql_tools@0.0.2/mod.ts';
+import { buildCacheKey } from './utils.ts';
 
 import type {
   Redis,
   GraphQLSchema,
-  GraphQLResolveInfo,
   DenostoreArgs,
   Middleware,
   Context,
-  SetOpts,
+  defaultExArg,
+  redisClientArg,
+  redisPortArg,
+  userSchemaArg,
+  cacheArgs,
+  cacheCallbackArg,
+  optsVariable,
 } from './types.ts';
 
 export default class Denostore {
   #usePlayground: boolean;
-  #redisClient: Redis;
-  #schema: GraphQLSchema;
+  #redisClient!: Redis;
+  #schema!: GraphQLSchema;
   #router: Router;
   #route: string;
-  #defaultEx: number | undefined;
+  #defaultEx: defaultExArg;
 
   constructor(args: DenostoreArgs) {
     const {
       schema,
       usePlayground = false,
       redisClient,
+      redisPort,
       route = '/graphql',
-      defaultEx = undefined,
+      defaultEx,
     } = args;
+
+    this.#setSchemaProperty(schema);
+    this.#setRedisClientProperty(redisClient, redisPort);
     this.#usePlayground = usePlayground;
-    this.#redisClient = redisClient;
-    this.#schema = schema;
     this.#router = new Router();
     this.#route = route;
     this.#defaultEx = defaultEx;
   }
 
-  async cache(
-    { info, ex }: { info: GraphQLResolveInfo; ex?: number },
-    // deno-lint-ignore ban-types
-    callback: { (): Promise<{}> | {} }
-  ) {
-    // console.log(info);
-    // extract query name from info object
-    const queryExtractName = queryExtract(info);
-    // console.log(queryExtractName);
-    const value = await this.#redisClient.get(queryExtractName);
+  async #setRedisClientProperty(
+    redisClient: redisClientArg,
+    redisPort: redisPortArg
+  ): Promise<void> {
+    if (redisClient) {
+      this.#redisClient = redisClient;
+    } else {
+      this.#redisClient = await connect({
+        hostname: 'localhost',
+        port: redisPort,
+      });
+    }
+  }
 
-    // cache hit: respond with parsed data
-    let results;
-    if (value) {
+  #setSchemaProperty(schema: userSchemaArg): void {
+    if ('typeDefs' in schema || 'resolvers' in schema) {
+      this.#schema = makeExecutableSchema({
+        typeDefs: schema.typeDefs,
+        resolvers: schema.resolvers || {},
+      });
+    } else {
+      this.#schema = schema;
+    }
+  }
+
+  /** 
+   ** Caching method to be invoked in the field resolver of queries user wants cached
+   ** Creates cache key by accessing resolver 'info' AST for query information
+   ** Accepts optional expire time in seconds argument
+   ** Retrieves cached value using created cache key
+   ** If cache key does not exist for a query, invokes provided callback and sets cache with results
+  */
+  async cache({ info, ex }: cacheArgs, callback: cacheCallbackArg) {
+    const cacheKey = buildCacheKey(info);
+    const cacheValue = await this.#redisClient.get(cacheKey);
+
+    // cache hit: return cached data
+    if (cacheValue) {
       console.log('Returning cached result');
-      results = JSON.parse(value);
-      return results;
+      return JSON.parse(cacheValue);
     }
 
-    //cache miss: set cache and respond with results
-    results = await callback();
+    // cache miss: invoke provided callback to fetch results
+    const results = await callback();
     if (results === null || results === undefined) {
       console.error(
         '%cError: result of callback provided to Denostore cache function cannot be undefined or null',
@@ -68,40 +100,47 @@ export default class Denostore {
 
     console.log('cache miss');
 
-    // declare opts variable
-    let opts: SetOpts | undefined;
+    // redis caching options
+    let opts: optsVariable;
 
-    // if positive expire argument specified, set expire in options
+    // if positive expire argument specified, set expire time in options
     if (ex) {
       if (ex > 0) opts = { ex: ex };
-      // if expire arg not specified look for default expiration
+      // else set default expire time in options if provided
     } else if (this.#defaultEx) {
       opts = { ex: this.#defaultEx };
     }
 
-    // set cache with options if specified
-    opts
-      ? await this.#redisClient.set(
-          queryExtractName,
-          JSON.stringify(results),
-          opts
-        )
-      : // if no options specified set cache with no expiration
-        await this.#redisClient.set(queryExtractName, JSON.stringify(results));
+    // set results in cache with options if specified
+    if (opts) {
+      await this.#redisClient.set(
+        cacheKey,
+        JSON.stringify(results),
+        opts
+      );
+      /**
+       * If negative expire argument provided or no expire specified, cache results with no expiration
+       * Uses negative number to indicate no expiration to avoid adding unnecessary expire flag argument
+       * while still fulfilling Redis type checks
+       */
+    } else {
+      await this.#redisClient.set(cacheKey, JSON.stringify(results));
+    }
 
     return results;
   }
 
+  /**
+   * Removes all keys and values from redis instance
+   */
   async clear(): Promise<void> {
-    // clears the cache completely of all data
     await this.#redisClient.flushall();
     console.log('cleared cache');
   }
 
   routes(): Middleware {
-    // check if usePlayground is passed in truthy and render playground
+    // render Playground IDE if enabled
     if (this.#usePlayground) {
-      // renders pseudo-graphiql using playground IDE
       this.#router.get(this.#route, (ctx: Context): void => {
         const { request, response } = ctx;
         try {
@@ -118,28 +157,31 @@ export default class Denostore {
           );
           response.status = 500;
           response.body = 'Problem rendering GraphQL Playground IDE';
+          throw err;
         }
       });
     }
 
-    //handles posted query and responds
+    // where GraphQL queries are handled
     this.#router.post(this.#route, async (ctx: Context): Promise<void> => {
       const { response, request } = ctx;
       try {
-        const body = await request.body();
-        const { query, variables } = await body.value;
+        const { query, variables } = await request.body().value;
 
-        //caching happens inside of resolvers (nested within schema, so graphql func invocation)
-        const results = await graphql({
+        // resolve GraphQL query
+        const graphqlResults = await graphql({
           schema: this.#schema,
           source: query,
+          // pass denostore instance through context to use methods in resolvers
           contextValue: { denostore: this },
           variableValues: variables,
         });
+
         // if errors delete results data
-        results.errors ? delete results.data : null;
-        response.status = results.errors ? 500 : 200;
-        response.body = results;
+        if (graphqlResults.errors) delete graphqlResults.data;
+        // respond with resolved query results
+        response.status = graphqlResults.errors ? 500 : 200;
+        response.body = graphqlResults;
         return;
       } catch (err) {
         console.error(
@@ -162,11 +204,9 @@ export default class Denostore {
       return;
     });
 
-    // gives our class the imported router's routes method
     return this.#router.routes();
   }
 
-  // gives our class the imported router's allowedMethods method
   allowedMethods(): Middleware {
     return this.#router.allowedMethods();
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,33 @@
-//interface for the shape of each test and types of key/values
+import type { Redis } from 'https://deno.land/x/redis@v0.25.3/mod.ts';
+import type {
+  GraphQLSchema,
+  GraphQLResolveInfo,
+  FieldNode,
+  ArgumentNode,
+} from 'https://deno.land/x/graphql_deno@v15.0.0/mod.ts';
+import type {
+  Middleware,
+  Context,
+} from 'https://deno.land/x/oak@v10.2.0/mod.ts';
 
-export interface RouterArgs {
-  schema: any;
+export interface DenostoreArgs {
+  schema: GraphQLSchema;
+  redisClient: Redis;
+  route?: string;
   usePlayground?: boolean;
   defaultCacheExpire?: number | boolean;
-  redisClient?: any;
 }
+
+export interface QueryObjType {
+  readonly name: string;
+  readonly arguments?: ReadonlyArray<ArgumentNode>;
+}
+
+export type {
+  Redis,
+  GraphQLSchema,
+  GraphQLResolveInfo,
+  Middleware,
+  Context,
+  FieldNode,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,8 @@
+//interface for the shape of each test and types of key/values
+
+export interface RouterArgs {
+  schema: any;
+  usePlayground?: boolean;
+  defaultCacheExpire?: number | boolean;
+  redisClient?: any;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Redis } from 'https://deno.land/x/redis@v0.25.3/mod.ts';
+import type { Redis, SetOpts } from 'https://deno.land/x/redis@v0.25.3/mod.ts';
 import type {
   GraphQLSchema,
   GraphQLResolveInfo,
@@ -15,12 +15,15 @@ export interface DenostoreArgs {
   redisClient: Redis;
   route?: string;
   usePlayground?: boolean;
-  defaultCacheExpire?: number | boolean;
+  defaultEx?: number | undefined;
 }
 
+type Maybe<T> = null | undefined | T;
 export interface QueryObjType {
   readonly name: string;
   readonly arguments?: ReadonlyArray<ArgumentNode>;
+  // deno-lint-ignore no-explicit-any
+  readonly variables?: Maybe<{ [key: string]: any }>;
 }
 
 export type {
@@ -30,4 +33,5 @@ export type {
   Middleware,
   Context,
   FieldNode,
+  SetOpts,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,25 +4,67 @@ import type {
   GraphQLResolveInfo,
   FieldNode,
   ArgumentNode,
+  DocumentNode,
+  DefinitionNode,
+  Source,
 } from 'https://deno.land/x/graphql_deno@v15.0.0/mod.ts';
 import type {
   Middleware,
   Context,
 } from 'https://deno.land/x/oak@v10.2.0/mod.ts';
+import type { IResolvers } from 'https://deno.land/x/graphql_tools@0.0.2/utils/interfaces.ts';
 
 export interface DenostoreArgs {
-  schema: GraphQLSchema;
-  redisClient: Redis;
+  schema: userSchemaArg;
+  redisClient?: Redis;
+  redisPort?: number;
   route?: string;
   usePlayground?: boolean;
   defaultEx?: number | undefined;
 }
 
-type Maybe<T> = null | undefined | T;
-export interface QueryObjType {
+export type defaultExArg = number | undefined;
+
+export type redisClientArg = Redis | undefined;
+
+export type redisPortArg = number | undefined;
+
+export type userSchemaArg = GraphQLSchema | ExecutableSchemaArgs;
+
+export type cacheCallbackArg = { (): Promise<{}> | {} };
+
+export type optsVariable = SetOpts | undefined;
+
+export interface cacheArgs {
+  /**
+   ** resolver info object must be passed to cache function for access to query
+   */
+  info: GraphQLResolveInfo;
+  /**
+   ** expire time in seconds
+   ** use -1 to specify no expiration
+   */
+  ex?: number;
+}
+
+export type ITypedefDS =
+  | string
+  | Source
+  | DocumentNode
+  | GraphQLSchema
+  | DefinitionNode
+  | Array<ITypedefDS>
+  | (() => ITypedefDS);
+
+export interface ExecutableSchemaArgs<TContext = any> {
+  typeDefs: ITypedefDS; // type definitions used to make schema
+  resolvers?: IResolvers<any, TContext> | Array<IResolvers<any, TContext>>; // resolvers for the type definitions
+}
+
+export type Maybe<T> = null | undefined | T;
+export interface CacheKeyObj {
   readonly name: string;
   readonly arguments?: ReadonlyArray<ArgumentNode>;
-  // deno-lint-ignore no-explicit-any
   readonly variables?: Maybe<{ [key: string]: any }>;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,14 @@
+const queryParser = (queryString:string):string => {
+    let queryName = '';
+    let curlyCount = 0;
+    for (let i = 0; i < queryString.length && curlyCount < 2; i++){
+      if (queryString[i] === '{') curlyCount++;
+      if (curlyCount === 1 && queryString[i] !== '{') {
+        queryName += queryString[i];
+      }
+    }
+    queryName = queryName.trim();
+    return queryName;
+  }
+
+export { queryParser };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,34 +1,7 @@
-import { QueryObjType, GraphQLResolveInfo } from './types.ts';
+import { FieldNode, CacheKeyObj, GraphQLResolveInfo } from './types.ts';
 
-// const queryParser = (queryString: string): string => {
-//   if (queryString === '') {
-//     console.error(
-//       '%cError finding query in the resolver.',
-//       'font-weight: bold; color: white; background-color: red;'
-//     );
-//     throw new Error('Query error. See server console.');
-//   }
-//   if (queryString[0] === 'm') {
-//     console.error(
-//       '%cDenostore cache function does not allow caching of mutations.',
-//       'font-weight: bold; color: white; background-color: red;'
-//     );
-//     throw new Error('Query error. See server console.');
-//   }
-//   let queryName = '';
-//   let curlyCount = 0;
 
-//   for (let i = 0; i < queryString.length && curlyCount < 2; i++) {
-//     if (queryString[i] === '{') curlyCount++;
-//     if (curlyCount === 1 && queryString[i] !== '{') {
-//       queryName += queryString[i];
-//     }
-//   }
-//   queryName = queryName.trim();
-//   return queryName;
-// };
-
-const queryExtract = (info: GraphQLResolveInfo): string => {
+const buildCacheKey = (info: GraphQLResolveInfo): string => {
   if (info.operation.operation === 'mutation') {
     console.error(
       '%cDenostore cache function does not allow caching of mutations.',
@@ -36,15 +9,14 @@ const queryExtract = (info: GraphQLResolveInfo): string => {
     );
     throw new Error('Query error. See server console.');
   }
-  const node = info.fieldNodes[0];
-  const queryObj: QueryObjType = {
+  const node: FieldNode = info.fieldNodes[0];
+  const cacheKeyObj: CacheKeyObj = {
     name: node.name.value,
     arguments: node.arguments,
     variables: info.variableValues,
   };
 
-  //find node name value as one key, args on another key
-  return JSON.stringify(queryObj);
+  return JSON.stringify(cacheKeyObj);
 };
 
-export { queryExtract };
+export { buildCacheKey };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,14 +1,41 @@
-const queryParser = (queryString:string):string => {
-    let queryName = '';
-    let curlyCount = 0;
-    for (let i = 0; i < queryString.length && curlyCount < 2; i++){
-      if (queryString[i] === '{') curlyCount++;
-      if (curlyCount === 1 && queryString[i] !== '{') {
-        queryName += queryString[i];
-      }
-    }
-    queryName = queryName.trim();
-    return queryName;
-  }
+import { QueryObjType, FieldNode } from './types.ts';
 
-export { queryParser };
+// const queryParser = (queryString: string): string => {
+//   if (queryString === '') {
+//     console.error(
+//       '%cError finding query in the resolver.',
+//       'font-weight: bold; color: white; background-color: red;'
+//     );
+//     throw new Error('Query error. See server console.');
+//   }
+//   if (queryString[0] === 'm') {
+//     console.error(
+//       '%cDenostore cache function does not allow caching of mutations.',
+//       'font-weight: bold; color: white; background-color: red;'
+//     );
+//     throw new Error('Query error. See server console.');
+//   }
+//   let queryName = '';
+//   let curlyCount = 0;
+
+//   for (let i = 0; i < queryString.length && curlyCount < 2; i++) {
+//     if (queryString[i] === '{') curlyCount++;
+//     if (curlyCount === 1 && queryString[i] !== '{') {
+//       queryName += queryString[i];
+//     }
+//   }
+//   queryName = queryName.trim();
+//   return queryName;
+// };
+
+const queryExtract = (node: FieldNode): string => {
+  const queryObj: QueryObjType = {
+    name: node.name.value,
+    arguments: node.arguments,
+  };
+
+  //find node name value as one key, args on another key
+  return JSON.stringify(queryObj);
+};
+
+export { queryExtract };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { QueryObjType, FieldNode } from './types.ts';
+import { QueryObjType, GraphQLResolveInfo } from './types.ts';
 
 // const queryParser = (queryString: string): string => {
 //   if (queryString === '') {
@@ -28,10 +28,12 @@ import { QueryObjType, FieldNode } from './types.ts';
 //   return queryName;
 // };
 
-const queryExtract = (node: FieldNode): string => {
+const queryExtract = (info: GraphQLResolveInfo): string => {
+  const node = info.fieldNodes[0];
   const queryObj: QueryObjType = {
     name: node.name.value,
     arguments: node.arguments,
+    variables: info.variableValues,
   };
 
   //find node name value as one key, args on another key

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,13 @@ import { QueryObjType, GraphQLResolveInfo } from './types.ts';
 // };
 
 const queryExtract = (info: GraphQLResolveInfo): string => {
+  if (info.operation.operation === 'mutation') {
+    console.error(
+      '%cDenostore cache function does not allow caching of mutations.',
+      'font-weight: bold; color: white; background-color: red;'
+    );
+    throw new Error('Query error. See server console.');
+  }
   const node = info.fieldNodes[0];
   const queryObj: QueryObjType = {
     name: node.name.value,

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -1,0 +1,2 @@
+//test the types?
+//test the resolvers -> expect a query to resolve with the data available on public API at same restful query

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,41 @@
+import {
+  assertEquals,
+  assertNotEquals,
+} from 'https://deno.land/std@0.128.0/testing/asserts.ts';
+import { connect } from 'https://deno.land/x/redis@v0.25.2/mod.ts';
+
+/**
+ test application invocation worked
+ test denostore function returned instance of denostore imported class
+ test optional arguments working properly in denostore function
+ test routes working
+ test speed reduction of repeated query (aka cache worked)
+
+ mock schemas
+ mock queries
+ */
+// Compact form: name and function
+// Deno.test('hello world #1', () => {
+//   const x = 1 + 2;
+//   assertEquals(x, 3);
+// });
+
+//test Redis connection and caching
+Deno.test('redisClient', async (t) => {
+  const redisClient = await connect({
+    hostname: 'localhost',
+    port: 6379,
+  });
+
+  await t.step('key/value saved to cache successfully', async () => {
+    await redisClient.set('key', 'value');
+    const test = await redisClient.get('key');
+    assertEquals('value', test);
+  });
+  await t.step('clear cache successfully', async () => {
+    await redisClient.flushdb();
+    const test = await redisClient.get('key');
+    assertNotEquals('value', test);
+  });
+  redisClient.quit();
+});


### PR DESCRIPTION
Key features of DenoStore:
- Class with various methods
- Caching queries regardless of the fields
- Accepts either schema or typedefs/resolvers
- Accepts either redis port number or redisClient
- Support for various GraphQL queries(fragments, operationNames, variables, arguments, sub-field arguments, etc.)
- Modular cache function where you can use for certain queries
- Cache expiration supported
- Default expiration for all cached queries 
- Serves Playground for graphql UI
- Clear function, which clears out everything in cache
